### PR TITLE
New displaced curve label

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## unreleased
+
+- Add Displaced paramter to curve label
+
 ## somenergia-ui-0.5.1 2024-11-16
 
 - Fix: remove unused parameters from formatTooltipLabel

--- a/lib/Chart/dataFormat.js
+++ b/lib/Chart/dataFormat.js
@@ -53,31 +53,32 @@ export const formatXAxis = (period, item) => {
 export const formatTooltipLabel = (period, values, type = 'barChart', displaced = false) => {
   // Displaced parameter: indicates if values are final or initial.
   // If true, values are final. Ex: for hour 1 label should be '00h - 01h'
-  // If false, values are initial. Ex: fir hour 1 label should be '01h - 02h'
+  // If false, values are initial. Ex: for hour 1 label should be '01h - 02h'
   const formatDay = (values) => dayjs(values).format('DD/MM/YYYY')
-  const hour = (values) => dayjs(values).format('HH')
-  var initialHour, finalHour
+  const hour = (values, addition=0) => dayjs(values).add(addition, 'hour').format('HH')
+  let initialHour, finalHour
 
+  const formatedDay = formatDay(values)
   if (displaced) {
-    initialHour = (values) => dayjs(values).add(-1, 'hour').format('HH')
-    finalHour = hour
+    initialHour = hour(values, -1)
+    finalHour = hour(values)
   } else {
-    initialHour = hour
-    finalHour = (values) => dayjs(values).add(1, 'hour').format('HH')
+    initialHour = hour(values)
+    finalHour = hour(values, 1)
   }
 
-  const formatWithHour = (values) => formatDay(values) + ' ' + initialHour(values) + 'h - ' + finalHour(values) + 'h'
+  const formatWithHour = formatedDay + ' ' + initialHour + 'h - ' + finalHour + 'h'
 
   switch (period) {
     case 'DAILY':
-      return formatWithHour(values)
+      return formatWithHour
     case 'WEEKLY':
     case 'MONTHLY':
       return type === 'barChart'
-        ? formatDay(values)
-        : formatWithHour(values)
+        ? formatedDay
+        : formatWithHour
     default:
-      return formatDay(values)
+      return formatedDay
   }
 }
 

--- a/lib/Chart/dataFormat.js
+++ b/lib/Chart/dataFormat.js
@@ -50,12 +50,23 @@ export const formatXAxis = (period, item) => {
   }
 }
 
-export const formatTooltipLabel = (period, values, type = 'barChart') => {
-  const formatWithHour = (values) =>
-    dayjs(values).format('DD/MM/YYYY HH') +
-    'h - ' +
-    dayjs(values).add(1, 'hour').format('HH') +
-    ' h'
+export const formatTooltipLabel = (period, values, type = 'barChart', displaced = false) => {
+  // Displaced parameter: indicates if values are final or initial.
+  // If true, values are final. Ex: for hour 1 label should be '00h - 01h'
+  // If false, values are initial. Ex: fir hour 1 label should be '01h - 02h'
+  const formatDay = (values) => dayjs(values).format('DD/MM/YYYY')
+  const hour = (values) => dayjs(values).format('HH')
+  var initialHour, finalHour
+
+  if (displaced) {
+    initialHour = (values) => dayjs(values).add(-1, 'hour').format('HH')
+    finalHour = hour
+  } else {
+    initialHour = hour
+    finalHour = (values) => dayjs(values).add(1, 'hour').format('HH')
+  }
+
+  const formatWithHour = (values) => formatDay(values) + ' ' + initialHour(values) + 'h - ' + finalHour(values) + 'h'
 
   switch (period) {
     case 'DAILY':
@@ -63,10 +74,10 @@ export const formatTooltipLabel = (period, values, type = 'barChart') => {
     case 'WEEKLY':
     case 'MONTHLY':
       return type === 'barChart'
-        ? dayjs(values).format('DD/MM/YYYY')
+        ? formatDay(values)
         : formatWithHour(values)
     default:
-      return dayjs(values).format('DD/MM/YYYY')
+      return formatDay(values)
   }
 }
 

--- a/lib/Chart/index.jsx
+++ b/lib/Chart/index.jsx
@@ -59,6 +59,7 @@ function Chart({
   maxYAxisValue = 'auto',
   minYAxisValue = 'auto',
   tickCountValue = 7,
+  displaced = false,
 }) {
   const getChartType = (type, data, period, legend, compareData) => {
     setChartLang(lang)
@@ -90,7 +91,7 @@ function Chart({
           </YAxis>
           <Tooltip
             formatter={(value) => formatTooltip(value, Ylegend)}
-            labelFormatter={(value) => formatTooltipLabel(period, value, 'lineChart')}
+            labelFormatter={(value) => formatTooltipLabel(period, value, 'lineChart', displaced)}
             contentStyle={{ fontWeight: 'bold' }}
           />
           <Line


### PR DESCRIPTION
## Description

Curves data can be initial or final, this should be reflected in labels. For example if data hour is 01:00 and final hour, that means that it represents information of the last hour, label should be '00h - 01h'. But if data hour is initial, that means that it represents information of the next hour, label should be '01h - 02h'.

## Changes

- A boolean parameter Displaced is added to the function that returns the label. False if initial hour, and True is final. By default it is False.

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

