### PR TITLE
🐛 add displace and scale parameters to curves charts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change log
 
+## unreleased
+
+- Use displace parameter in charts
+- Add scale parameter to shown auto (in the middle of the bar) or band (to the beginning of the bar)
+- Unified day-hour tooltip
+
 ## 1.0.1 2026-03-17
 
 - Fix: DatePicker component

--- a/lib/CurveChart/index.jsx
+++ b/lib/CurveChart/index.jsx
@@ -28,6 +28,7 @@ function CurveChart({
   compareData,
   lang,
   Ylegend = 'kWh',
+  displaced = false,
 }) {
   setChartLang(lang)
   const mixedData = mergeData(data, compareData)
@@ -59,7 +60,7 @@ function CurveChart({
           </YAxis>
           <Tooltip
             formatter={(value) => formatTooltip(value, Ylegend)}
-            labelFormatter={(value) => formatTooltipLabel(period, value, 'lineChart')}
+            labelFormatter={(value) => formatTooltipLabel(period, value, 'lineChart', displaced)}
             contentStyle={{ fontWeight: 'bold' }}
           />
           <Line
@@ -92,6 +93,7 @@ CurveChart.propTypes = {
   compareData: PropTypes.oneOfType([PropTypes.array]),
   lang: PropTypes.string,
   Ylegend: PropTypes.string,
+  displaced: PropTypes.bool,
 }
 
 export default CurveChart

--- a/lib/SummaryBarChart/CustomTooltip.jsx
+++ b/lib/SummaryBarChart/CustomTooltip.jsx
@@ -3,12 +3,16 @@ import Box from '@mui/material/Box'
 import { Paper, Typography } from '@mui/material'
 import dayjs from 'dayjs'
 import { alpha } from "@mui/system/colorManipulator";
+import {
+  formatTooltipLabel,
+} from '../utils/chart.utils'
 
-export const CustomTooltip = ({ active, payload, Ylegend, showTooltipKeys }) => {
+export const CustomTooltip = ({ active, payload, period, Ylegend, showTooltipKeys, displaced = false }) => {
   if (active && payload && payload.length) {
     const date = dayjs(payload[0].payload.date)
     const dateFormat = `${date.format('DD/MM/YYYY')}`
-    const formatWithHour = `${date.format('HH')}h - ${date.add(1, 'hour').format('HH')}h`
+
+    const formatWithHour = formatTooltipLabel(period, date, 'barChart', displaced)
     return (
       <Paper variant="outlined" sx={{ padding: '10px' }}>
         <Box
@@ -20,10 +24,6 @@ export const CustomTooltip = ({ active, payload, Ylegend, showTooltipKeys }) => 
             alignItems: 'center',
           }}
         >
-          <Typography
-            variant="subtitle2"
-            sx={{ color: '#585857', fontWeight: 'bold' }}
-          >{`${dateFormat}`}</Typography>
           <Typography
             variant="subtitle2"
             sx={{ color: '#585857', fontWeight: 'bold' }}
@@ -51,5 +51,6 @@ CustomTooltip.propTypes = {
   active: PropTypes.bool,
   payload: PropTypes.array,
   Ylegend: PropTypes.string,
+  period: PropTypes.string,
   showTooltipKeys: PropTypes.bool,
 }

--- a/lib/SummaryBarChart/index.jsx
+++ b/lib/SummaryBarChart/index.jsx
@@ -34,7 +34,9 @@ function SummaryPeriodChart({
   numberOfDecimals,
   maxYAxisValue = 'auto',
   minYAxisValue = 'auto',
-  tickCountValue = 7
+  tickCountValue = 7,
+  displaced = false,
+  scale = 'band',
 }) {
   setChartLang(lang)
   return (
@@ -46,9 +48,9 @@ function SummaryPeriodChart({
           <XAxis
             dataKey="date"
             tickFormatter={(tickItem) => formatXAxis(period, tickItem)}
-            tick={{ fontSize: '1rem', transform: 'translate(0, 8)' }}
+            tick={{ fontSize: '1rem', transform: 'translate(0, 8)'}}
             padding={{ left: 24, right: 24 }}
-            scale="band"
+            scale={scale}
             xAxisId="values"
           />
           <YAxis
@@ -68,7 +70,7 @@ function SummaryPeriodChart({
           </YAxis>
           <Tooltip
             content={
-              <CustomTooltip Ylegend={Ylegend} showTooltipKeys={showTooltipKeys} />
+              <CustomTooltip period={period} Ylegend={Ylegend} showTooltipKeys={showTooltipKeys} displaced={displaced} />
             }
             cursor={{ fill: '#f2f2f2bb' }}
           />
@@ -118,6 +120,8 @@ SummaryPeriodChart.propTypes = {
   Ylegend: PropTypes.string,
   showTooltipKeys: PropTypes.bool,
   referenceLineData: PropTypes.oneOfType([PropTypes.array]),
+  displaced: PropTypes.bool,
+  scale: PropTypes.string,
 }
 
 export default SummaryPeriodChart

--- a/lib/utils/chart.utils.js
+++ b/lib/utils/chart.utils.js
@@ -76,6 +76,7 @@ export const formatTooltipLabel = (period, values, type = 'barChart', displaced 
     case 'DAILY':
       return formatWithHour
     case 'WEEKLY':
+      return formatedDay
     case 'MONTHLY':
       return type === 'barChart'
         ? formatedDay

--- a/lib/utils/chart.utils.js
+++ b/lib/utils/chart.utils.js
@@ -76,7 +76,9 @@ export const formatTooltipLabel = (period, values, type = 'barChart', displaced 
     case 'DAILY':
       return formatWithHour
     case 'WEEKLY':
-      return formatedDay
+      return type === 'barChart'
+        ? formatedDay
+        : formatWithHour
     case 'MONTHLY':
       return type === 'barChart'
         ? formatedDay

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-i18next": "14.1.3",
     "recharts": "2.15.4",
     "storybook": "7.6.21",
-    "styled-components": "^6.3.9",
+    "styled-components": "6.3.9",
     "vite": "4.5.14",
     "vite-plugin-svgr": "4.5.0",
     "vite-plugin-eslint": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-i18next": "14.1.3",
     "recharts": "2.15.4",
     "storybook": "7.6.21",
-    "styled-components": "6.3.9",
+    "styled-components": "^6.3.9",
     "vite": "4.5.14",
     "vite-plugin-svgr": "4.5.0",
     "vite-plugin-eslint": "^1.8.1",


### PR DESCRIPTION
## Description

Some curves are shown considering final hour and others initial hour.

## Changes

- Use displace parameter
- Scale is parameterized to shown at the beginning or the middle of the bar chart
- Day and hour tooltip is unified

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation